### PR TITLE
Improve cleanup commands

### DIFF
--- a/io.github.tobagin.scramble.yml
+++ b/io.github.tobagin.scramble.yml
@@ -11,8 +11,12 @@ finish-args:
 
 cleanup:
   - /include
-  - /lib/pkgconfig
   - /lib/cmake
+  - /lib/girepository-1.0
+  - /lib/pkgconfig
+  - /share/gir-1.0
+  - /share/man
+  - /share/vala
   - "*.a"
 
 modules:


### PR DESCRIPTION
Drop the development-related files to reduce the Flatpak size.